### PR TITLE
Return deferreds and don't discard API data

### DIFF
--- a/resources/test/processed-hosts.edn
+++ b/resources/test/processed-hosts.edn
@@ -1,0 +1,58 @@
+({:physical-appliance-id "F83BEDB4-4027-1005-8535-0050568525D9",
+  :ips ["172.16.10.5"],
+  :name "123455",
+  :status-data
+  {:details [],
+   :inst-type "appliance",
+   :reported-by "clyde",
+   :status "ok",
+   :stream "offline",
+   :timestamp 1477915297},
+  :type "appliance",
+  :created {:at 1477915296, :by 0},
+  :update-policy {:id "B0D5C6EF-0007-1005-9BF4-080027CDAF96"},
+  :modified {:at 1477915296, :by 0},
+  :customer {:id 1111},
+  :status "ok",
+  :id "F83BEDB4-4027-1005-8535-0050568525D9",
+  :metadata
+  {:host-type "standalone",
+   :local-hostname "123455",
+   :local-ipv-6
+   ["fe80::be30:5bff:fee2:f0fd" "fe80::be30:5bff:fee2:f0fe"],
+   :local-ipv-4 ["172.16.10.5"],
+   :os-details
+   "Linux; 2.6.32-642.6.2.el6.x86_64; #1 SMP Wed Oct 26 06:52:09 UTC 2016; x86_64",
+   :total-mem-mb 15938,
+   :version "1",
+   :num-logical-processors 4,
+   :os-type "unix"}}
+ {:ips ["10.15.0.1" "192.168.0.13"],
+  :name "987654",
+  :status-data
+  {:details [],
+   :inst-type "host",
+   :reported-by "clyde",
+   :status "offline",
+   :stream "offline",
+   :timestamp 1461077002},
+  :type "host",
+  :created {:at 1456887153, :by 0},
+  :update-policy {:id "B0D5C6EF-0007-1005-9BF4-080027CDAF96"},
+  :modified {:at 1456887153, :by 0},
+  :customer {:id 1111},
+  :status "offline",
+  :id "F8D4ABD7-2D07-1005-8673-0050568505BC",
+  :metadata
+  {:host-type "standalone",
+   :local-hostname "987654",
+   :local-ipv-6
+   ["fe80::baca:3aff:fe68:7d40" "fe80::baca:3aff:fe68:7d41"],
+   :local-ipv-4 ["10.15.0.1" "192.168.0.13"],
+   :os-details
+   "Linux; 2.6.32-573.22.1.el6.x86_64; #1 SMP Thu Mar 17 03:23:39 EDT 2016; x86_64",
+   :is-role false,
+   :total-mem-mb 129014,
+   :version "1",
+   :num-logical-processors 24,
+   :os-type "unix"}})

--- a/src/alertlogic_lib/core.clj
+++ b/src/alertlogic_lib/core.clj
@@ -1,5 +1,6 @@
 (ns alertlogic-lib.core
   (:require
+   [clojure.set :refer [rename-keys]]
    [clojure.string :as str]
    [aleph.http :as http]
    [byte-streams :as bs]
@@ -57,7 +58,8 @@
   "Fetches customer info from the Alert Logic API."
   [root-customer-id api-token]
   (let [url (str base-url (format customer-api root-customer-id))]
-    (:child-chain @(get-page! url api-token))))
+    (md/chain (get-page! url api-token)
+              :child-chain)))
 
 (defn get-customers-map!
   "Given a root customer ID, returns a map of child customer
@@ -66,7 +68,7 @@
   Provided root-customer-id must correspond to an Alert Logic
   customer ID (integer string)."
   [root-customer-id api-token]
-  (customer-json-to-id-map (get-customers! root-customer-id api-token)))
+  (customer-json-to-id-map @(get-customers! root-customer-id api-token)))
 
 (defn get-lm-devices-for-customer!
   "Gets a list of devices active in the Alert Logic Log
@@ -76,14 +78,18 @@
   (integer string)."
   [customer-id api-token]
   (if (nil? customer-id)
-    (error "Customer ID cannot be nil. Aborting.")
+    (do
+      (error "Customer ID cannot be nil. Aborting.")
+      (md/success-deferred []))
     (let [url (str base-url-public (format lm-hosts-api customer-id))
-          hosts (:hosts @(get-page! url api-token))
           cleanup-host
-          (fn [host]
-            (let [{{:keys [name status metadata type]} :host} host]
-              {:name name
-               :status (:status status)
-               :ips (:local-ipv-4 metadata)
-               :type type}))]
-      (map cleanup-host hosts))))
+          (fn [{:keys [host]}]
+            (let [{:keys [status metadata]} host]
+              (merge
+               (rename-keys host {:status :status-data})
+               {:status (:status status)
+                :ips (:local-ipv-4 metadata)})))]
+      (md/chain
+       (get-page! url api-token)
+       :hosts
+       #(map cleanup-host %)))))  ;; transducer version of map doesn't work here

--- a/src/alertlogic_lib/core.clj
+++ b/src/alertlogic_lib/core.clj
@@ -68,7 +68,8 @@
   Provided root-customer-id must correspond to an Alert Logic
   customer ID (integer string)."
   [root-customer-id api-token]
-  (customer-json-to-id-map @(get-customers! root-customer-id api-token)))
+  (md/chain (get-customers! root-customer-id api-token)
+            customer-json-to-id-map))
 
 (defn get-lm-devices-for-customer!
   "Gets a list of devices active in the Alert Logic Log

--- a/test/alertlogic_lib/core_test.clj
+++ b/test/alertlogic_lib/core_test.clj
@@ -25,10 +25,12 @@
         (is (= {:hosts []}
                @(get-page! "" "")))))))
 
-(deftest get-customers!-tests
+(def customers
+  [{:customer-id 101 :customer-name "123-lol"}
+   {:customer-id 1111 :customer-name "746228 Ltd."}])
+
+(deftest customer-json-to-id-map-tests
   (let [cj->id #'alertlogic-lib.core/customer-json-to-id-map
-        customers [{:customer-id 101 :customer-name "123-lol"}
-                   {:customer-id 1111 :customer-name "746228 Ltd."}]
         customers-map {"123" "101"
                        "746228" "1111"}
         check-output (fn [input expected]
@@ -38,26 +40,31 @@
     (testing "handles bad customer names"
       (let [customer-data [{:customer-id 101 :customer-name "lol"}]]
         (check-output customer-data {})))
+    (testing "handles null customer names"
+      (let [customer-data [{:customer-id 101 :customer-name nil}]]
+        (check-output customer-data {})))
     (testing "handles good customer names"
       (let [customer-data [{:customer-id 101 :customer-name "123-lol"}]]
         (check-output customer-data {"123" "101"})))
     (testing "handles many customers"
-      (check-output customers customers-map))
-    (let [root-customer-data {:api-key "supar-sekret"
-                              :customer-id 31337
-                              :customer-name "SuperCustomer"
-                              :child-chain customers}
-          fake-get (fake-get-success root-customer-data)]
-      (with-redefs [aleph.http/get fake-get]
-        (testing "handles download"
-          (let [expected customers
-                output (get-customers! "31337" "supar-sekret")]
-            (is (= expected output))))
-        (testing "handles download and formatting"
-          (let [expected {"123" "101"
-                          "746228" "1111"}
-                output (get-customers-map! "31337" "supar-sekret")]
-            (is (= expected output))))))))
+      (check-output customers customers-map))))
+
+(deftest get-customers!-tests
+  (let [root-customer-data {:api-key "supar-sekret"
+                            :customer-id 31337
+                            :customer-name "SuperCustomer"
+                            :child-chain customers}
+        fake-get (fake-get-success root-customer-data)]
+    (with-redefs [aleph.http/get fake-get]
+      (testing "handles download"
+        (let [expected customers
+              output @(get-customers! "31337" "supar-sekret")]
+          (is (= expected output))))
+      (testing "handles download and formatting"
+        (let [expected {"123" "101"
+                        "746228" "1111"}
+              output (get-customers-map! "31337" "supar-sekret")]
+          (is (= expected output)))))))
 
 (defn use-atom-log-appender!
   "Adds a log observer that saves its log messages to an atom.
@@ -82,24 +89,20 @@
 (deftest get-lm-devices!-tests
   (testing "taps out when id is null"
     (let [log (use-atom-log-appender!)]
-      (get-lm-devices-for-customer! nil "some-token")
+      @(get-lm-devices-for-customer! nil "some-token")
       (is (= 1 (count @log)))
       (is (s/includes? (first @log) "Customer ID cannot be nil. Aborting."))))
   (testing "handles an empty device list"
     (let [fake-get (fake-get-success {:hosts []})]
       (with-redefs [aleph.http/get fake-get]
-        (is (empty? (get-lm-devices-for-customer! "1111" "some-token"))))))
+        (is (empty? @(get-lm-devices-for-customer! "1111" "some-token"))))))
   (testing "handles some devices"
-    (let [body (read-string (slurp (resource "test/hosts.edn")))
+    (let [body (-> "test/hosts.edn" resource slurp read-string)
           fake-get (fake-get-success body)]
       (with-redefs [aleph.http/get fake-get]
-        (let [expected '({:name "123455"
-                          :type "appliance"
-                          :status "ok"
-                          :ips ["172.16.10.5"]}
-                         {:name "987654"
-                          :type "host"
-                          :status "offline"
-                          :ips ["10.15.0.1" "192.168.0.13"]})
-              output (get-lm-devices-for-customer! "1111" "some-token")]
+        (let [expected (-> "test/processed-hosts.edn"
+                           resource
+                           slurp
+                           read-string)
+              output @(get-lm-devices-for-customer! "1111" "some-token")]
           (is (= expected output)))))))

--- a/test/alertlogic_lib/core_test.clj
+++ b/test/alertlogic_lib/core_test.clj
@@ -63,7 +63,7 @@
       (testing "handles download and formatting"
         (let [expected {"123" "101"
                         "746228" "1111"}
-              output (get-customers-map! "31337" "supar-sekret")]
+              output @(get-customers-map! "31337" "supar-sekret")]
           (is (= expected output)))))))
 
 (defn use-atom-log-appender!


### PR DESCRIPTION
Fixes #14.

Here I fix some bad design choices I initially made. We stop discarding
useful API data, and we no longer dereference returned deferreds for the
consumer.