### PR TITLE
Handle multiple Alert Logic account IDs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+# 0.3.0
+
+API changes:
+
+- AL Customer IDs in the customer map are returned as a list of matching IDs,
+  for those customers that have multiple AL accounts.
+
 # 0.2.0
 
 API changes:

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject alertlogic-lib "0.2.1-SNAPSHOT"
+(defproject alertlogic-lib "0.3.0-SNAPSHOT"
   :description "A library for interacting with Alert Logic APIs."
   :lein-release {:deploy-via :clojars}
   :url "http://github.com/RackSec/alertlogic-lib"

--- a/src/alertlogic_lib/core.clj
+++ b/src/alertlogic_lib/core.clj
@@ -51,7 +51,7 @@
                      (remove #(nil? (:id %))))  ;; might be some non-matches
         add-customer-to-map
         (fn [customer-map customer]
-          (assoc customer-map (:id customer) (str (:al-id customer))))]
+          (update customer-map (:id customer) conj (str (:al-id customer))))]
     (reduce add-customer-to-map {} id-list)))
 
 (defn get-customers!

--- a/test/alertlogic_lib/core_test.clj
+++ b/test/alertlogic_lib/core_test.clj
@@ -31,8 +31,6 @@
 
 (deftest customer-json-to-id-map-tests
   (let [cj->id #'alertlogic-lib.core/customer-json-to-id-map
-        customers-map {"123" "101"
-                       "746228" "1111"}
         check-output (fn [input expected]
                        (is (= expected (cj->id input))))]
     (testing "handles empty case"
@@ -45,9 +43,17 @@
         (check-output customer-data {})))
     (testing "handles good customer names"
       (let [customer-data [{:customer-id 101 :customer-name "123-lol"}]]
-        (check-output customer-data {"123" "101"})))
+        (check-output customer-data {"123" ["101"]})))
     (testing "handles many customers"
-      (check-output customers customers-map))))
+      (let [customer-data {"123" ["101"]
+                           "746228" ["1111"]}]
+        (check-output customers customer-data)))
+    (testing "handles repeat accounts"
+      (let [customers (conj customers {:customer-id 111
+                                       :customer-name "123-lol 2"})
+            customer-data {"123" ["111" "101"]
+                           "746228" ["1111"]}]
+        (check-output customers customer-data)))))
 
 (deftest get-customers!-tests
   (let [root-customer-data {:api-key "supar-sekret"
@@ -61,8 +67,8 @@
               output @(get-customers! "31337" "supar-sekret")]
           (is (= expected output))))
       (testing "handles download and formatting"
-        (let [expected {"123" "101"
-                        "746228" "1111"}
+        (let [expected {"123" ["101"]
+                        "746228" ["1111"]}
               output @(get-customers-map! "31337" "supar-sekret")]
           (is (= expected output)))))))
 


### PR DESCRIPTION
Closes [DI-525](https://tree.taiga.io/project/fboxwala-rms-development-di/task/525).

For customers that have multiple Alert Logic accounts, associate all their IDs into the customer/json map rather than selecting the last encountered.